### PR TITLE
Added support for CORS enabled images

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ import logging
 import datetime
 import hashlib
 import flask
-from flask import Flask, render_template, request, send_file
+from flask import Flask, render_template, request, make_response, send_file
 from helpers.fakeimg import FakeImg
 from helpers.converters import ColorConverter, ImgSizeConverter, AlphaConverter
 try:
@@ -67,8 +67,9 @@ def placeholder(width, height=None,
         "retina": "retina" in request.args
     }
     image = FakeImg(**args)
-    # return static file
-    return send_file(image.raw, mimetype='image/png', add_etags=False)
+    response = make_response(send_file(image.raw, mimetype='image/png', add_etags=False))
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    return response
 
 
 # caching stuff

--- a/tests.py
+++ b/tests.py
@@ -193,6 +193,9 @@ class AppTestCase(unittest.TestCase):
             width, height = img.size
             self.assertEqual(width, 200)
             self.assertEqual(height, 100)
+    def testCORSHeaders(self):
+        with self.app.get('/200x100/') as r:
+            self.assertEqual(r.headers['Access-Control-Allow-Origin'], '*')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The use case is testing canvas painting from another domain, then exporting the result as data URI. The CORS header is required by modern browsers to provide a correct `CanvasRenderingContext2D.prototype.toDataURL()` output.

More informations: https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image