### PR TITLE
Added webp support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Jérôme Mahuet <jerome.mahuet@gmail.com>"
 
 RUN apk --update --no-cache add \
     build-base \
+    libwebp-dev \
     python-dev \
     jpeg-dev \
     libpng \

--- a/app/helpers/fakeimg.py
+++ b/app/helpers/fakeimg.py
@@ -12,7 +12,7 @@ class FakeImg:
         pil_image (PIL.Image.Image): PIL object.
         raw (str): Real image in PNG format.
     """
-    def __init__(self, width, height, background_color, foreground_color, alpha_background, alpha_foreground,
+    def __init__(self, width, height, background_color, foreground_color, alpha_background, alpha_foreground, image_type,
                  text=None, font_name=None, font_size=None, retina=False):
         """Init FakeImg with parameters.
 
@@ -25,6 +25,7 @@ class FakeImg:
             foreground_color (str): The text color of the image. It should be in web hexadecimal format.
                 Example: #FFF, #123456.
             alpha_foreground (int): Alpha value of the foreground color.
+            image_type (string): The image type which can be "png" or "webp".
             text (str): Optional. The actual text which will be drawn on the image.
                 Default: f"{width} x {height}"
             font_name (str): Optional. The font name to use.
@@ -42,6 +43,7 @@ class FakeImg:
         self.alpha_background = alpha_background
         self.foreground_color = f"#{foreground_color}"
         self.alpha_foreground = alpha_foreground
+        self.image_type = image_type
         self.text = text or f"{width} x {height}"
         self.font_name = font_name or "yanone"
         try:
@@ -62,9 +64,13 @@ class FakeImg:
     def raw(self):
         """Create the image on memory and return it"""
         img_io = BytesIO()
-        self.pil_image.save(img_io, 'PNG')
+        self.pil_image.save(img_io, self.image_type.upper())
         img_io.seek(0)
         return img_io
+
+    @property
+    def mimetype(self):
+        return "image/{image_type}".format(image_type = self.image_type)
 
     def _calculate_font_size(self):
         min_side = min(self.width, self.height)

--- a/app/main.py
+++ b/app/main.py
@@ -26,22 +26,50 @@ def index():
 
 
 @app.route('/<i:width>/')
+@app.route('/<i:width>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>/<c:bgd>/')
+@app.route('/<i:width>/<c:bgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>/<c:bgd>,<a:alphabgd>/')
+@app.route('/<i:width>/<c:bgd>,<a:alphabgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>/<c:bgd>/<c:fgd>/')
+@app.route('/<i:width>/<c:bgd>/<c:fgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>/<c:bgd>,<a:alphabgd>/<c:fgd>/')
+@app.route('/<i:width>/<c:bgd>,<a:alphabgd>/<c:fgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>/<c:bgd>/<c:fgd>,<a:alphafgd>/')
+@app.route('/<i:width>/<c:bgd>/<c:fgd>,<a:alphafgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>/<c:bgd>,<a:alphabgd>/<c:fgd>,<a:alphafgd>/')
+@app.route('/<i:width>/<c:bgd>,<a:alphabgd>/<c:fgd>,<a:alphafgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>x<i:height>/')
+@app.route('/<i:width>x<i:height>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>x<i:height>/<c:bgd>/')
+@app.route('/<i:width>x<i:height>/<c:bgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>x<i:height>/<c:bgd>,<a:alphabgd>/')
+@app.route('/<i:width>x<i:height>/<c:bgd>,<a:alphabgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>x<i:height>/<c:bgd>/<c:fgd>/')
+@app.route('/<i:width>x<i:height>/<c:bgd>/<c:fgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>x<i:height>/<c:bgd>,<a:alphabgd>/<c:fgd>/')
+@app.route('/<i:width>x<i:height>/<c:bgd>,<a:alphabgd>/<c:fgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>x<i:height>/<c:bgd>/<c:fgd>,<a:alphafgd>/')
+@app.route('/<i:width>x<i:height>/<c:bgd>/<c:fgd>,<a:alphafgd>/<image_name>.<any("png", "webp):image_type>')
+
 @app.route('/<i:width>x<i:height>/<c:bgd>,<a:alphabgd>/<c:fgd>,<a:alphafgd>/')
+@app.route('/<i:width>x<i:height>/<c:bgd>,<a:alphabgd>/<c:fgd>,<a:alphafgd>/<image_name>.<any("png", "webp):image_type>')
+
 def placeholder(width, height=None,
                 bgd="cccccc", fgd="909090",
-                alphabgd=255, alphafgd=255):
+                alphabgd=255, alphafgd=255, image_name="", image_type="png"):
     """This endpoint generates the placeholder itself, based on arguments.
     If the height is missing, just make the image square.
     """
@@ -56,10 +84,11 @@ def placeholder(width, height=None,
         "text": request.args.get('text'),
         "font_name": request.args.get('font'),
         "font_size": request.args.get('font_size'),
-        "retina": "retina" in request.args
+        "retina": "retina" in request.args,
+        "image_type": image_type,
     }
     image = FakeImg(**args)
-    response = make_response(send_file(image.raw, mimetype='image/png', etag=False))
+    response = make_response(send_file(image.raw, mimetype=image.mimetype, etag=False))
     response.headers['Access-Control-Allow-Origin'] = '*'
     return response
 


### PR DESCRIPTION
Hi there,

I'm using your nice image project for development and there I need webp support in addition to the already existing png images.
Therefor I added support for it in your project.

All previously existing urls should still work and use the png image type (no backward incompatible changes i hope)
Additionally you can now suffix all the routes with an image name and type.
If you specify the type then you must specify a name tho.

###  Example
These will return a png
```
http://localhost:9000/288x162/009895/109895/
http://localhost:9000/288x162/009895/109895/image.png
http://localhost:9000/288x162/009895/109895/green-ish.png
```

And these return a webp
```
http://localhost:9000/288x162/009895/109895/image.webp
http://localhost:9000/288x162/009895/109895/green-ish.webp
```

These will fail (could be added with additional routes)
```
http://localhost:9000/288x162/009895/109895/.png
http://localhost:9000/288x162/009895/109895/.webp
```

I'm not a python developer so my change might not be to your standards, if so please let me know so I can change it.

Hopefully you can accept this pull request and create a new docker image so everyone can use it.

have a nice day